### PR TITLE
Don't run E2E on dependabot PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,8 @@ jobs:
     name: e2e_tests
     runs-on: ubuntu-22.04
 
+    if: (github.actor != 'dependabot[bot]')
+    
     steps:
       - name: Checkout icm-relayer repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Dependabot can't access secrets, so it can't use the token to execute the e2e tests.