### PR TITLE
Handle os signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ TOKEN_FILE_PATH="./token.json" go run main/main.go
 ### E2E tests
 
 #### Running Locally
-To run E2E locally follow the [key creation](#key-creation) steps above to generate a new key associated with the `e2e_signer` role, and generate a session token file saved as `e2e_session.json`. After that the tests can be run via 
+
+To run E2E locally follow the [key creation](#key-creation) steps above to generate a new key associated with the `e2e_signer` role, and generate a session token file saved as `e2e_session.json`. After that the tests can be run via
 
 ```bash
 ./scripts/e2e_test.sh


### PR DESCRIPTION
Gracefully handles os signals and cancels the parent context.

Also fixes a few linter warnings in the README